### PR TITLE
[!] wxc-mask: fix bug that inconsistent behavior between clicking close button and clicking overlay

### DIFF
--- a/packages/wxc-mask/index.vue
+++ b/packages/wxc-mask/index.vue
@@ -22,7 +22,8 @@ under the License.
 
 <template>
   <div class="container">
-    <wxc-overlay :show="show && hasOverlay"
+    <wxc-overlay ref="overlay"
+                 :show="show && hasOverlay"
                  v-if="show"
                  v-bind="mergeOverlayCfg"
                  :can-auto-close="overlayCanClose"
@@ -191,7 +192,7 @@ under the License.
     },
     methods: {
       closeIconClicked () {
-        this.appearMask(false);
+        this.$refs.overlay.appearOverlay(false);
       },
       wxcOverlayBodyClicking () {
         if (this.hasAnimation) {

--- a/packages/wxc-pan-item/index.vue
+++ b/packages/wxc-pan-item/index.vue
@@ -63,10 +63,12 @@ under the License.
       setTimeout(() => {
         if (this.supportAndroid && this.needSlider) {
           const element = this.$refs['wxc-pan-item'];
-          Binding.prepare && Binding.prepare({
-            anchor: element.ref,
-            eventType: 'pan'
-          });
+          if (element) {
+            Binding.prepare && Binding.prepare({
+              anchor: element.ref,
+              eventType: 'pan'
+            });
+          }
         }
       }, 300)
     },


### PR DESCRIPTION
Now clicking the close button in the component wxc-mask will only close the mask, not overlay. I think this is a bug, so I fix it.