### PR TITLE
[+] wxc-pan-item: add judgment before using element

### DIFF
--- a/packages/wxc-pan-item/index.vue
+++ b/packages/wxc-pan-item/index.vue
@@ -63,10 +63,12 @@ under the License.
       setTimeout(() => {
         if (this.supportAndroid && this.needSlider) {
           const element = this.$refs['wxc-pan-item'];
-          Binding.prepare && Binding.prepare({
-            anchor: element.ref,
-            eventType: 'pan'
-          });
+          if (element) {
+            Binding.prepare && Binding.prepare({
+              anchor: element.ref,
+              eventType: 'pan'
+            });
+          }
         }
       }, 300)
     },


### PR DESCRIPTION
The element may no longer exist because the function will execute after 300 ms.
https://github.com/apache/incubator-weex-ui/blob/c233792979be02bec17a2f20d432d72f073c5dc9/packages/wxc-pan-item/index.vue#L63