### PR TITLE
[!] wxc-mask: fix bug that inconsistent behavior between clicking close button and clicking overlay

### DIFF
--- a/packages/wxc-mask/index.vue
+++ b/packages/wxc-mask/index.vue
@@ -193,6 +193,9 @@ under the License.
     methods: {
       closeIconClicked () {
         this.$refs.overlay.appearOverlay(false);
+        if (!this.overlayCanClose) {
+          this.appearMask(false);
+        }
       },
       wxcOverlayBodyClicking () {
         if (this.hasAnimation) {

--- a/packages/wxc-mask/index.vue
+++ b/packages/wxc-mask/index.vue
@@ -22,7 +22,8 @@ under the License.
 
 <template>
   <div class="container">
-    <wxc-overlay :show="show && hasOverlay"
+    <wxc-overlay ref="overlay"
+                 :show="show && hasOverlay"
                  v-if="show"
                  v-bind="mergeOverlayCfg"
                  :can-auto-close="overlayCanClose"
@@ -191,7 +192,7 @@ under the License.
     },
     methods: {
       closeIconClicked () {
-        this.appearMask(false);
+        this.$refs.overlay.appearOverlay(false);
       },
       wxcOverlayBodyClicking () {
         if (this.hasAnimation) {


### PR DESCRIPTION
Now clicking the close button in the component WxcMask will only close the mask, not overlay. I think this is a bug, so I fix it.